### PR TITLE
do not modify column names in counts matrix

### DIFF
--- a/scripts/ds_plots.R
+++ b/scripts/ds_plots.R
@@ -17,6 +17,8 @@ cluster_significance_file=arguments$args[3]
 cat("Loading counts from",counts_file,"\n")
 if (!file.exists(counts_file)) stop("File ",counts_file," does not exist")
 counts=read.table(counts_file, header=T)
+# Bypass default R behavior, so we do not modify the original column names.
+colnames(counts) <- strsplit(readLines(counts_file, n = 1), " ")[[1]]
 
 cat("Loading metadata from",groups_file,"\n")
 if (!file.exists(groups_file)) stop("File ",groups_file," does not exist")

--- a/scripts/leafcutter_ds.R
+++ b/scripts/leafcutter_ds.R
@@ -21,6 +21,8 @@ groups_file=arguments$args[2]
 cat("Loading counts from",counts_file,"\n")
 if (!file.exists(counts_file)) stop("File ",counts_file," does not exist")
 counts=read.table(counts_file, header=T)
+# Bypass default R behavior, so we do not modify the original column names.
+colnames(counts) <- strsplit(readLines(counts_file, n = 1), " ")[[1]]
 
 cat("Loading metadata from",groups_file,"\n")
 if (!file.exists(groups_file)) stop("File ",groups_file," does not exist")


### PR DESCRIPTION
By default, the `read.table()` function in R calls `make.names()` to make
syntactically valid names. This is a problem if you have column names that
contain '-' or '_' or '+'.

See: https://stat.ethz.ch/R-manual/R-devel/library/base/html/make.names.html

This patch fixes that issue, so the column names are not altered.
