### PR TITLE
set leafCutterDir relative to script location

### DIFF
--- a/scripts/bam2junc.sh
+++ b/scripts/bam2junc.sh
@@ -1,5 +1,5 @@
 
-leafCutterDir='..'
+leafCutterDir=$(dirname $0)/..
 bamfile=$1
 bedfile=$1.bed
 juncfile=$2


### PR DESCRIPTION
Proposed change would allow script to run from any directory, sourcing leafcutter directory from the script location. 
Current code requires running of this script from a subdirectory of the leafcutter directory.