### PR TITLE
Replacement for wrangle_annotation.sh script

### DIFF
--- a/leafviz/gtf2leafcutter.pl
+++ b/leafviz/gtf2leafcutter.pl
@@ -58,6 +58,11 @@ while (<IN>){
       my $sTranscriptID = exists $rhAnnots->{'transcript_id'} ? $rhAnnots->{'transcript_id'} : "";
       my $sTag          = exists $rhAnnots->{'tag'}           ? join("|", @{$rhAnnots->{'tag'}}) : "";
       
+      # Fall back options if gene name is empty
+      unless ($sGeneName){
+         $sGeneName = $sGeneID ? $sGeneID : 'Unknown';
+      }
+      
       # Try to get the biotype; there are differences between gtf versions so let's traverse the various options in order of preference
       my $sBiotype = "";
       if ( exists $rhAnnots->{'transcript_type'} ){

--- a/leafviz/gtf2leafcutter.pl
+++ b/leafviz/gtf2leafcutter.pl
@@ -1,0 +1,198 @@
+#!/usr/bin/perl
+
+# MODULES
+use strict;
+use warnings;
+use Getopt::Long;
+
+# GET PARAMETERS
+my $sHelp         = 0;
+my $sOutputPrefix = "leafviz-annotations";
+GetOptions("help!"   => \$sHelp);
+
+# GLOBALS
+my %hMultiCopyTags = ('tag'=>'','Dbxref'=>'','gbkey'=>'','Name'=>'','product'=>'','Note'=>'','tss_id'=>'', 'ont'=>'');
+
+
+# PRINT HELP
+$sHelp = 1 unless(@ARGV>0);
+if ($sHelp) {
+   my $sScriptName = ($0 =~ /^.*\/(.+$)/) ? $1 : $0;
+   die <<HELP
+
+   Usage: $sScriptName <gtf-file>
+   
+   Convert a gtf file to a set of annotation files to be used with leafviz.
+   
+   Arguments: 
+    -o --output <string>
+      Output file prefix. Default: $sOutputPrefix
+    
+    -help
+      This help message
+   
+HELP
+}
+
+
+##########
+## MAIN ##
+##########
+
+# Collect attribute combination counts
+my %hOut;
+my $nCountSkips = 0;
+my $nCountParse = 0;
+open IN, $ARGV[0] or die "Error: can't open '$ARGV[0]': $!\n";
+while (<IN>){
+   next if (/^\s*$/);
+   next if (/^ *#/);
+   s/[\n\r]+$//;
+   my ($sChr, $sSource, $sFeature, $nStart, $nEnd, $nScore, $sStrand, $nFrame, $sGroup) = split /\t/, $_, -1;
+   if ( lc($sFeature) eq 'exon'){
+      my $rhAnnots = gtf_annots_to_hash($sGroup, \%hMultiCopyTags);
+      
+      # Get required annotation data
+      my $sGeneName     = exists $rhAnnots->{'gene_name'}     ? $rhAnnots->{'gene_name'} : "";
+      my $sGeneID       = exists $rhAnnots->{'gene_id'}       ? $rhAnnots->{'gene_id'} : "";
+      my $sTranscriptID = exists $rhAnnots->{'transcript_id'} ? $rhAnnots->{'transcript_id'} : "";
+      my $sTag          = exists $rhAnnots->{'tag'}           ? join("|", @{$rhAnnots->{'tag'}}) : "";
+      
+      # Try to get the biotype; there are differences between gtf versions so let's traverse the various options in order of preference
+      my $sBiotype = "";
+      if ( exists $rhAnnots->{'transcript_type'} ){
+         $sBiotype = $rhAnnots->{'transcript_type'};
+      }
+      elsif ( exists $rhAnnots->{'gene_type'} ){
+         $sBiotype = $rhAnnots->{'gene_type'};
+      }
+      elsif ( exists $rhAnnots->{'gene_biotype'} ){
+         $sBiotype = $rhAnnots->{'gene_biotype'};
+      }
+      else{
+         $sBiotype = "Unknown";
+      }
+      
+      # Write to hash with transcript_id as the key
+      if ($sTranscriptID){
+         if ( exists $hOut{$sTranscriptID} ){
+            # Check for basic consistency between exon annotations
+            if ( ($sChr eq $hOut{$sTranscriptID}{'chr'}) and ($sStrand eq $hOut{$sTranscriptID}{'strand'}) and ($sGeneName eq $hOut{$sTranscriptID}{'gene_name'}) and ($sGeneID eq $hOut{$sTranscriptID}{'gene_id'}) ){
+               push @{ $hOut{$sTranscriptID}{'exons'} }, [sort {$a <=> $b} ($nStart, $nEnd) ]; # Push exon block as an array of arrays.
+            }
+            else{
+               $nCountSkips++;
+            }
+         }
+         else{
+            $hOut{$sTranscriptID}{'chr'}           = $sChr;
+            $hOut{$sTranscriptID}{'strand'}        = $sStrand;
+            $hOut{$sTranscriptID}{'gene_name'}     = $sGeneName;
+            $hOut{$sTranscriptID}{'gene_id'}       = $sGeneID;
+            $hOut{$sTranscriptID}{'transcript_id'} = $sTranscriptID;
+            $hOut{$sTranscriptID}{'biotype'}       = $sBiotype;
+            $hOut{$sTranscriptID}{'tag'}           = $sTag;
+            push @{ $hOut{$sTranscriptID}{'exons'} }, [sort {$a <=> $b} ($nStart, $nEnd) ]; # Push exon block as an array of arrays.
+            $nCountParse++;
+         }
+      }
+      else{
+         $nCountSkips++;
+      }
+      
+   }
+}
+close IN;
+
+# Print some basic stats
+warn ("Read $nCountParse transcripts\n");
+warn ("Skipped $nCountSkips incorrectly formatted exon entries\n") if ($nCountSkips);
+
+
+# At this point we gathered everything we need from the GTF file; time to write the outputs
+if (keys %hOut){
+   
+   # Open output file handles
+   open ALLEXONS,   "| gzip -c > ${sOutputPrefix}_all_exons.txt.gz"   or die "Error can't write to '${sOutputPrefix}_all_exons.txt.gz': $!\n";
+   open ALLINTRONS, "| sort -s -t '\t' -k5,5 -k7,7 -k8,8n | gzip -c > ${sOutputPrefix}_all_introns.bed.gz" or die "Error can't write to '${sOutputPrefix}_all_introns.bed.gz': $!\n";
+   open FIVEPRIME,  "| sort -s -t '\t' -k5,5 -k7,7 -k8,8n | gzip -c > ${sOutputPrefix}_fiveprime.bed.gz"   or die "Error can't write to '${sOutputPrefix}_all_fiveprime.bed.gz': $!\n";
+   open THREEPRIME, "| sort -s -t '\t' -k5,5 -k7,7 -k8,8n | gzip -c > ${sOutputPrefix}_threeprime.bed.gz"  or die "Error can't write to '${sOutputPrefix}_all_threeprime.bed.gz': $!\n";
+   
+   # Write a header for the exon file
+   print ALLEXONS "chr\tstart\tend\tstrand\tgene_name\n";
+   
+   # Start cycling through transcripts
+   foreach my $sTranscriptID (keys %hOut){
+      my %hT = %{$hOut{$sTranscriptID}}; # Transcript details
+      my @aE = @{$hT{'exons'}};          # Array of arrays with exons
+      
+      # Sort exons by start coordinate, ascending
+      @aE = sort { $a->[0] <=> $b->[0] } @aE;
+      
+      # Write to all_exon file
+      foreach my $rExon (@aE){
+         my ($nStart, $nEnd) = @$rExon;
+         print ALLEXONS join ("\t", $hT{'chr'}, $nStart, $nEnd, $hT{'strand'}, $hT{'gene_name'}), "\n";
+      }
+      
+      # Write to all_intron file and write 5' and 3' ends
+      for ( my $i = 0 ; $i < $#aE ; $i++){
+         my $nIstart = $aE[$i][1];
+         my $nIend   = $aE[$i+1][0];
+         if ( ($nIend - $nIstart) > 0 ){
+            my $nIntronID = $hT{'strand'} eq '+' ? $i+1 : $#aE-$i;
+            print ALLINTRONS join ("\t", $hT{'chr'}, $nIstart, $nIend, $hT{'gene_name'}, $hT{'gene_id'}, $hT{'strand'}, $hT{'transcript_id'}, $nIntronID, $hT{'biotype'}, $hT{'tag'} ), "\n";
+            print FIVEPRIME  join ("\t", $hT{'chr'}, $nIstart, $nIstart + 1, $hT{'gene_name'}, $hT{'gene_id'}, $hT{'strand'}, $hT{'transcript_id'}, $nIntronID, $hT{'biotype'}, $hT{'tag'} ), "\n";
+            print THREEPRIME join ("\t", $hT{'chr'}, $nIend,   $nIend + 1,   $hT{'gene_name'}, $hT{'gene_id'}, $hT{'strand'}, $hT{'transcript_id'}, $nIntronID, $hT{'biotype'}, $hT{'tag'} ), "\n";
+            
+            # Set 5' and 3' ends based on whether the feature is on the forward on reverse strand; seems to break leafviz visualization so disabled for now
+            #if ( $hT{'strand'} eq '+' ){
+               #print FIVEPRIME  join ("\t", $hT{'chr'}, $nIstart, $nIstart + 1, $hT{'gene_name'}, $hT{'gene_id'}, $hT{'strand'}, $hT{'transcript_id'}, $nIntronID, $hT{'biotype'}, $hT{'tag'} ), "\n";
+               #print THREEPRIME join ("\t", $hT{'chr'}, $nIend,   $nIend + 1,   $hT{'gene_name'}, $hT{'gene_id'}, $hT{'strand'}, $hT{'transcript_id'}, $nIntronID, $hT{'biotype'}, $hT{'tag'} ), "\n";
+            #}
+            #else{
+               #print FIVEPRIME  join ("\t", $hT{'chr'}, $nIend,   $nIend + 1,   $hT{'gene_name'}, $hT{'gene_id'}, $hT{'strand'}, $hT{'transcript_id'}, $nIntronID, $hT{'biotype'}, $hT{'tag'} ), "\n";
+               #print THREEPRIME join ("\t", $hT{'chr'}, $nIstart, $nIstart + 1, $hT{'gene_name'}, $hT{'gene_id'}, $hT{'strand'}, $hT{'transcript_id'}, $nIntronID, $hT{'biotype'}, $hT{'tag'} ), "\n";
+            #}
+         }
+      }
+   }
+   
+   # Close filehandles
+   close ALLEXONS;
+   close ALLINTRONS;
+   close FIVEPRIME;
+   close THREEPRIME;
+}
+else{
+   warn("No exon entries found in input file\n");
+}
+
+
+
+#################
+## SUBROUTINES ##
+#################
+
+# gtf_annots_to_hash
+#
+# Parse gtf annotations and return key-value pairs
+sub gtf_annots_to_hash {
+   my ($sAnnots, $rMultiCopy) = @_;
+   my %hReturn;
+   
+   my @asPairs = split / *; */, $sAnnots;
+   foreach my $sPair (@asPairs){
+      my ($sKey, $sVal) = split(/ /, $sPair, 2);
+      $sVal =~ s/"//g;
+      if ( exists $rMultiCopy->{$sKey} ){
+         push @{$hReturn{$sKey}}, $sVal;
+      }
+      else{
+         die "Error: Duplicate key entry '$sKey' found with values '$hReturn{$sKey}' and '$sVal'\n" if (exists $hReturn{$sKey});
+         $hReturn{$sKey} = $sVal;
+      }
+   }
+   return \%hReturn;
+}
+

--- a/leafviz/prepare_results.R
+++ b/leafviz/prepare_results.R
@@ -88,6 +88,7 @@ if(file.exists(counts_file)){
 if(file.exists(groups_file)){
   cat("Loading metadata from",groups_file,"\n")
   meta <- read.table(groups_file, header=F, stringsAsFactors = F)
+  meta = meta[,1:2]
   colnames(meta)=c("sample","group")
 
   sample_table <- data.frame( group = names(table(meta$group) ), count = as.vector(table(meta$group)) )

--- a/leafviz/prepare_results.R
+++ b/leafviz/prepare_results.R
@@ -82,7 +82,7 @@ if( !file.exists(system("which bedtools", intern=TRUE) )){
 
 if(file.exists(counts_file)){
   cat("Loading counts from",counts_file,"\n")
-  counts <- read.table(counts_file)
+  counts <- read.table(counts_file, check.names=FALSE)
 }
 
 if(file.exists(groups_file)){

--- a/leafviz/prepare_results.R
+++ b/leafviz/prepare_results.R
@@ -124,6 +124,14 @@ results <- fread(results.file, stringsAsFactors = F)
 
 results$FDR <- p.adjust( results$p, method = "fdr")
 
+# If there were no significant results, stop here and provide feedback to the user by printing
+# an error message and writing an empty file indicating that no significant clusters were found at this FDR threshold
+if( !any(results$FDR < FDR_limit, na.rm=T) ){
+   write.table( data.frame(), file=paste0(resultsFolder,"/no-significant-clusters-found.txt"), col.names=FALSE);
+   stop("No significant clusters found\n");
+}
+
+# Gather introns meeting the FDR threshold
 all.introns <- merge(x = results, y = effectSizes, by = "cluster")
 all.introns <- all.introns[ order(all.introns$FDR),]
 


### PR DESCRIPTION
This perl script should provide a more robust conversion of gtf files to the input file formats needed for leafviz, regardless of differences in formatting. I've tested it on a few input files but not super exhaustively so YMMV.

In putting this together I encountered what I think is a bug in the original conversion script. From what I understand, the intention was to set the 5' and 3' ends of introns based on whether the feature is on the + or - strand. However, in reality the script appears not to invert the 5' and 3' ends of introns for negative-strand features. The current version of the perl script replicates the same behavior as the original script because inverting the 5' and 3' ends for negative-strand features appears to break the visualization. What I think was the originally intended approach is commented out in lines 148 to 156. 

Now, since the 5' and 3' ends are not properly inverted for negative strand features, cryptic 5' and 3' events are currently mislabeled in leafviz. You can see this in the example that is provided on the website: Intron 'b' and intron 'c' for top hit RILPL1 are annotated as 'cryptic_threeprime' and 'cryptic_fiveprime', respectively. However, RILPL1 is on the negative strand, so the 5' splice donor sites are downstream from the 3' acceptor sites. This means that intron 'b' should be annotated as cryptic_fiveprime and intron 'c' should be annotated as cryptic_threeprime.

I think the logic in leafviz needs fixing to better account for the strand, with the correct 5' and 3' annotations for negative strand features.