### PR TITLE
add_chr on exons table in case reference exons lack chr naming

### DIFF
--- a/leafviz/prepare_results.R
+++ b/leafviz/prepare_results.R
@@ -83,6 +83,9 @@ exons_table=if (!is.null( exon_file )) {
   NULL
 }
 
+# in case the exons table lacks "chr" on the chr column
+exons_table$chr <- leafcutter::add_chr(exons_table$chr)
+
 effectSizes <- fread(effect.sizes.file, data.table=F )
 effectSizesSplit <-  as.data.frame(str_split_fixed(effectSizes$intron, ":", 4), stringsAsFactors = FALSE )
 names(effectSizesSplit) <- c("chr","start","end","clusterID")


### PR DESCRIPTION
In response to issue #75 , suggested by @lisavetasol 

as add_chr will only add "chr" to chromosome names when it doesn't already have them this should cause any unintended side effects. The *_all_exons.txt.gz file is created by the gtf2leafcutter.pl script so we could've potentially added the "chr" concatenation into that but this seems like an easy fix. 