### PR TITLE
clustering now ignores regtools ambiguous stranded junctions

### DIFF
--- a/scripts/leafcutter_cluster_regtools.py
+++ b/scripts/leafcutter_cluster_regtools.py
@@ -48,7 +48,8 @@ def pool_junc_reads(flist, options):
             if int(blockCount) > 2:
                 print ln
                 continue
-            
+            # regtools -s 0 (unstranded) now puts "?" in strand field when strand is ambiguous  
+            if strand == "?": continue            
             if checkchrom and (chrom not in chromLst): continue
             Aoff, Boff = blockSize.split(",")
             A, B = int(A)+int(Aoff), int(B)-int(Boff)+1

--- a/scripts/leafcutter_cluster_regtools_py3.py
+++ b/scripts/leafcutter_cluster_regtools_py3.py
@@ -55,7 +55,8 @@ def pool_junc_reads(flist, options):
             if int(blockCount) > 2:
                 print(ln)
                 continue
-
+            # regtools -s 0 (unstranded) now puts "?" in strand field when strand is ambiguous
+            if strand == "?": continue
             if checkchrom and (chrom not in chromLst): continue
             Aoff, Boff = blockSize.split(",")
             A, B = int(A)+int(Aoff), int(B)-int(Boff)+1


### PR DESCRIPTION
mentioned in issue #161, I suspect this is the cause of #153 too. 

Users switching to regtools were finding that leafcutter_cluster_regtools fails in unstranded mode (-s 0) due to a small number of ambiguously stranded junctions. This fixes the problem by ignoring ambiguously stranded junctions.

The documentation should be updated to suggest that if users have stranded RNA-seq libraries then they should extract their junctions with a strand-specific parameter -s ( 1 or 2).