### PR TITLE
Update leafcutter_cluster_regtools.py

### DIFF
--- a/clustering/leafcutter_cluster_regtools.py
+++ b/clustering/leafcutter_cluster_regtools.py
@@ -69,6 +69,8 @@ def pool_junc_reads(flist, options):
         read_ks.sort()
         
         sys.stderr.write("%s:%s.."%chrom)
+        if len(read_ks)<1 : continue #empty contig
+        
         clu = cluster_intervals(read_ks)[0]
         for cl in clu:
     


### PR DESCRIPTION
On new version of human genomes (Grch38), it is possible to get contigs (the generalisation of the concept of chromosome) with no junctions, and hence the program stops. This correction pass the contig if it is the case.