### PR TITLE
Add shebang line for leafcutter_cluster_regtools.py to fix an error.

### DIFF
--- a/clustering/leafcutter_cluster_regtools.py
+++ b/clustering/leafcutter_cluster_regtools.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # https://github.com/griffithlab/regtools
 # /home/yangili1/tools/regtools/build/regtools junctions extract -a 8 -i 50 -I 500000 bamfile.bam -o outfile.junc
 # Using regtools speeds up the junction extraction step by an order of magnitude or more


### PR DESCRIPTION
Hi,
Thank you for making the leafcutter package.
As it turns out, the leafcutter_cluster_regtools.py will be executed as a bash script and produce the following error:

```
Singularity> /opt/leafcutter/clustering/leafcutter_cluster_regtools.py
/opt/leafcutter/clustering/leafcutter_cluster_regtools.py: line 5: import: command not found
/opt/leafcutter/clustering/leafcutter_cluster_regtools.py: line 6: import: command not found
/opt/leafcutter/clustering/leafcutter_cluster_regtools.py: line 7: import: command not found
/opt/leafcutter/clustering/leafcutter_cluster_regtools.py: line 8: import: command not found
/opt/leafcutter/clustering/leafcutter_cluster_regtools.py: line 9: import: command not found
/opt/leafcutter/clustering/leafcutter_cluster_regtools.py: line 11: syntax error near unexpected token `('
/opt/leafcutter/clustering/leafcutter_cluster_regtools.py: line 11: `def main(options,libl):'
```

I think the cause is the lack of she-bang line, so that bash cannot recognize it as a python executable, which is why I made the changes.