### PR TITLE
Add shebang line to leafcutter_cluster_regtools.py

### DIFF
--- a/clustering/leafcutter_cluster_regtools.py
+++ b/clustering/leafcutter_cluster_regtools.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # https://github.com/griffithlab/regtools
 # /home/yangili1/tools/regtools/build/regtools junctions extract -a 8 -i 50 -I 500000 bamfile.bam -o outfile.junc
 # Using regtools speeds up the junction extraction step by an order of magnitude or more


### PR DESCRIPTION
This one script is missing a shebang line when all the others I looked at have it.  Helpful to make it easily executable by sticking it on the PATH.