### PR TITLE
Update prepare_results.R

### DIFF
--- a/leafviz/prepare_results.R
+++ b/leafviz/prepare_results.R
@@ -198,7 +198,7 @@ for( clu in clusters ){
   cluster_ensemblIDs <- names(sort(table( c(tprime$gene_id,fprime$gene_id)), decreasing = TRUE ))
   cluster_ensemblID <- cluster_ensemblIDs[ cluster_ensemblIDs != "." ][1]
   if( length( cluster_ensemblID ) == 0 ){
-    cluster_ensemblID == "."
+    cluster_ensemblID <- "."
   }
 
   verdict <- c()


### PR DESCRIPTION
When there are few splicing events, among those few none of them match with the annotated genes. This error is seen.

Few splicing events may arise because of
1. Few replicates
2. Lower depth of sequencing
3. Non-model organism with few annotated genes
4. any other...