### PR TITLE
Enable leafcutter-ds to handle a group_file with no confounder columns

### DIFF
--- a/leafcutter/differential_splicing/leafcutter_ds.py
+++ b/leafcutter/differential_splicing/leafcutter_ds.py
@@ -50,6 +50,7 @@ meta = pd.read_table(args.groups_file, header=None, sep = '\s+')
 meta = meta.rename(dict(zip([0, 1], ["sample", "group"])), axis = 1)
 
 # Check if there are more than 2 columns in the metadata DataFrame
+confounders = None
 if len(meta.columns) > 2:
     # Extract the confounders (columns 3 and onwards)
     confounders = meta.iloc[:, 2:]
@@ -71,17 +72,18 @@ if len(meta.columns) > 2:
     #remove samples with missing data (not in origial leafcutter as far as I can tell).
     confounders = pd.DataFrame(confounders, index = meta['sample']).dropna()
 
-all_samples = set(meta.loc[:,'sample'])
-removed_samples = all_samples - set(confounders.index)
-if len(removed_samples) != 0:
-    print('Samples removed due to missing values in covariates...')
-    print(','.join(list(removed_samples)))
-
-# Encode the "group" column as numeric (0 and 1)
-meta = meta[meta['sample'].isin(confounders.index)]
-
-#if permute: numeric_x = np.random.permutation(numeric_x)
-counts = counts[confounders.index]
+    # indented to here to fix confounders
+    all_samples = set(meta.loc[:,'sample'])
+    removed_samples = all_samples - set(confounders.index)
+    if len(removed_samples) != 0:
+        print('Samples removed due to missing values in covariates...')
+        print(','.join(list(removed_samples)))
+    # Encode the "group" column as numeric (0 and 1)
+    meta = meta[meta['sample'].isin(confounders.index)]
+    #if permute: numeric_x = np.random.permutation(numeric_x)
+    counts = counts[confounders.index]
+else:
+    counts = counts[meta["sample"].tolist()]
 
 scale_factor = 1.
 


### PR DESCRIPTION
`leafcutter-ds` would error out when no confounder columns were present in `group_file`, this is an attempt to fix that.

1. A default `confounders = None` variable is set
2. A chunk of code that manipulates the `confounders` DataFrame was pushed up into the `if len(meta.columns) > 2` block
3. If no confounders are present, the `counts` DataFrame is subset to just include the samples defined in `meta`

Please note I'm not a Python or pandas guru, so I'm sure there may be better (more idiomatic) ways to do this, but this seems to do what I think is intended to setup the ultimate call to `differential_splicing()`